### PR TITLE
Add missing request_timeout option to credential role

### DIFF
--- a/changelogs/fragments/cred_request_timeout.yml
+++ b/changelogs/fragments/cred_request_timeout.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Add missing request_timeout option to credential role

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -18,6 +18,7 @@
     controller_password:            "{{ controller_password | default(omit, true) }}"
     controller_oauthtoken:          "{{ controller_oauthtoken | default(omit, true) }}"
     controller_host:                "{{ controller_hostname | default(omit, true) }}"
+    request_timeout:                "{{ controller_request_timeout | default(omit, true) }}"
     controller_config_file:         "{{ controller_config_file | default(omit, true) }}"
     validate_certs:                 "{{ controller_validate_certs | default(omit) }}"
   loop: "{{ credentials if credentials is defined else controller_credentials }}"


### PR DESCRIPTION
**What does this PR do?**
Adds previously fixed missing request_timeout option to the credentials role

**How should this be tested?**
The option is available

**Is there a relevant Issue open for this?**
resolves https://github.com/redhat-cop/infra.aap_configuration/issues/936

**Other Relevant info, PRs, etc**
This is PR is against the new controller_configuration branch which will exist for backports like this. Releases can be done from this branch. In likelihood these will mostly be bug fixes like this and will be released as 2.11.z