### PR TITLE
Fix repo url

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you feel like getting your hands dirty, feel free to make the change yourself
 1. Fork the repo on Github, and then clone it locally.
 2. Create a branch named appropriately for the change you are going to make.
 3. Make your code change.
-4. If you are creating a new role, please add a test for it in our [testing playbook.](https://github.com/redhat-cop/controller_configuration/blob/devel/tests/configure_controller.yml) by adding a new role entry and adding the appropriate yaml file with test data in the controller_configs directory.
+4. If you are creating a new role, please add a test for it in our [testing playbook.](https://github.com/redhat-cop/infra.controller_configuration/blob/devel/tests/configure_controller.yml) by adding a new role entry and adding the appropriate yaml file with test data in the controller_configs directory.
 5. Add a changelog fragment in `changelogs/fragments` as per <https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs>
 6. Push your code change up to your forked repo.
 7. Open a Pull Request to merge your changes to this repo. The comment box will be filled in automatically via a template.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@ authors:
     - Sean Sullivan @sean-m-sullivan
     - David Danielsson @djdanielsson
 repository: https://github.com/redhat-cop/infra.controller_configuration/
-issues: https://github.com/redhat-cop/infra.controller_configuration//issues
+issues: https://github.com/redhat-cop/infra.controller_configuration/issues
 build_ignore:
     - galaxy.yml.j2
     - release.yml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,8 +11,8 @@ authors:
     - Tom Page @Tompage1994
     - Sean Sullivan @sean-m-sullivan
     - David Danielsson @djdanielsson
-repository: https://github.com/redhat-cop/controller_configuration/
-issues: https://github.com/redhat-cop/controller_configuration//issues
+repository: https://github.com/redhat-cop/infra.controller_configuration/
+issues: https://github.com/redhat-cop/infra.controller_configuration//issues
 build_ignore:
     - galaxy.yml.j2
     - release.yml


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->


Now the repo url https://github.com/redhat-cop/controller_configuration is redirected to https://github.com/redhat-cop/infra.aap_configuration.

So I fixed the repo url of `infra.controller_configuration` to  https://github.com/redhat-cop/infra.controller_configuration in docs.


# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
