### PR TITLE
Add inventory_source to constructed inventory

### DIFF
--- a/changelogs/fragments/filetree_create_24.yml
+++ b/changelogs/fragments/filetree_create_24.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - filetree_create - Corrected th4e following vars; controller_hostname, controller_oauthtoken, and controller_validate_certs
+minor_changes:
+  - Constructed inventories now produce an inventory source which can be used to control items such as limit and source_vars for the constructed inventory
+...

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -85,4 +85,26 @@
       loop_control:
         loop_var: current_inventories_asset_value
         label: "{{ __dest }}"
+
+- name: "Set the constructed inventory's inventory source"
+  ansible.builtin.include_tasks: "controller_inventory_sources.yml"
+  when: not skip_inventory_sources
+  vars:
+    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
+    inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
+    inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/controller_inventories/' + inventory_name | regex_replace('/', '_'))
+                                      if (flatten_output is not defined or (flatten_output | bool) == false)
+                                      else
+                                        output_path + '/inventory_sources.yaml' }}"
+    current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
+                                                    host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                                    return_all=true, max_objects=query_controller_api_max_objects)
+                                            }}"
+    last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
+  loop: "{{ constructed_inventory_lookvar }}"
+  loop_control:
+    index_var: current_inventory_index
+    loop_var: current_inventory_sources
+    label: "{{ inventory_sources_output_path }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 ...

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -87,7 +87,7 @@
         label: "{{ __dest }}"
 
 - name: "Set the constructed inventory's inventory source"
-  ansible.builtin.include_tasks: "controller_inventory_sources.yml"
+  ansible.builtin.include_tasks: "inventory_sources.yml"
   when: not skip_inventory_sources
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"

--- a/roles/filetree_create/templates/current_inventories.j2
+++ b/roles/filetree_create/templates/current_inventories.j2
@@ -88,8 +88,8 @@ controller_inventories:
 -%}
 {%   if _instance_groups | length > 0 %}
     instance_groups:
-{%    for _input_inventory in _instance_groups %}
-      - {{ _input_inventory.name }}
+{%    for _instance_group in _instance_groups %}
+      - {{ _instance_group.name }}
 {%    endfor %}
 {%   endif %}
 {% endif %}

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -10,10 +10,23 @@ controller_inventory_sources:
 {% if inventory_source.summary_fields.organization is defined %}
     organization: "{{ inventory_source.summary_fields.organization.name }}"
 {% endif %}
+    {% set _source_type = template_overrides_resources.inventory_source[inventory_source.name].source
+                | default(template_overrides_global.inventory_source.source)
+                | default(inventory_source.source)
+                | default('ToDo: The source of the inventory_source was originally missing and must be specified', true) %}
+{% if _source_type != 'constructed' %}
     source: "{{ template_overrides_resources.inventory_source[inventory_source.name].source
                 | default(template_overrides_global.inventory_source.source)
                 | default(inventory_source.source)
                 | default('ToDo: The source of the inventory_source was originally missing and must be specified', true) }}"
+{% endif %}
+{% if template_overrides_resources.inventory_source[inventory_source.name].limit is defined
+      or template_overrides_global.inventory_source.limit is defined
+      or inventory_source.limit is defined %}
+    limit: "{{ template_overrides_resources.inventory_source[inventory_source.name].limit
+                     | default(template_overrides_global.inventory_source.limit)
+                     | default(inventory_source.limit) }}"
+{% endif %}
 {% if template_overrides_resources.inventory_source[inventory_source.name].source_project is defined
       or template_overrides_global.inventory_source.source_project is defined
       or inventory_source.source_project is defined %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Allows the constructed inventory to have its implicit inventory_source

# How should this be tested?
Run with 
```
input_tag:
  - controller_inventories
```
and see that an inventory source now shows for a constructed inventory and that the limit etc. can be seen there.
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #24 

# Other Relevant info, PRs, etc

