### PR TITLE
Fix adding divider between job templates list

### DIFF
--- a/changelogs/fragments/66-fix_adding_divider_between_job_templates_list.yml
+++ b/changelogs/fragments/66-fix_adding_divider_between_job_templates_list.yml
@@ -1,0 +1,2 @@
+buxfixes:
+  - Fixes an issue with the filetree_create role adding a '...' separate between each item in the job templates list flatten output is set to true.

--- a/changelogs/fragments/66-fix_adding_divider_between_job_templates_list.yml
+++ b/changelogs/fragments/66-fix_adding_divider_between_job_templates_list.yml
@@ -1,3 +1,3 @@
-buxfixes:
+bugfixes:
   - Fixes an issue with the filetree_create role adding a '...' separate between each item in the job templates list flatten output is set to true.
   

--- a/changelogs/fragments/66-fix_adding_divider_between_job_templates_list.yml
+++ b/changelogs/fragments/66-fix_adding_divider_between_job_templates_list.yml
@@ -1,2 +1,3 @@
 buxfixes:
   - Fixes an issue with the filetree_create role adding a '...' separate between each item in the job templates list flatten output is set to true.
+  

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -261,6 +261,6 @@ controller_templates:
                                         | default(template_overrides_global.job_template.prevent_instance_group_fallback)
                                         | default(current_job_templates_asset_value.prevent_instance_group_fallback | bool | lower) }}
 {% endif %}
-{% if last_job_template | default(true) | bool | lower %}
+{% if last_job_template | default(true) | bool %}
 ...
 {% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes an issue with the filetree_create role adding a `...` separate between each item in the job templates list.

## How should this be tested?
Normal testing.

## Is there a relevant Issue open for this?
#65 

## Other Relevant info, PRs, etc
N/A
