### PR TITLE
Don't export the unified_job_template related info if it's not defined

### DIFF
--- a/changelogs/fragments/filtree_create_workflow_job_templates.yaml
+++ b/changelogs/fragments/filtree_create_workflow_job_templates.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - [filetree_create] Don't export the unified_job_template related info if it's not defined
+  - "filetree_create - Don't export the unified_job_template related info if it's not defined"
 ...

--- a/changelogs/fragments/filtree_create_workflow_job_templates.yaml
+++ b/changelogs/fragments/filtree_create_workflow_job_templates.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - [filetree_create] Don't export the unified_job_template related info if it's not defined
+...

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -21,7 +21,7 @@ controller_workflows:
 {% if node.summary_fields.unified_job_template is not defined %}
         unified_job_template: "ToDo: The node is pointing to a deleted Job Template"
 {% endif %}
-{% if node.summary_fields.unified_job_template is defined 
+{% if node.summary_fields.unified_job_template is defined and
       node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
         unified_job_template: "{{ node.summary_fields.unified_job_template.name }}"
 {%   if node.verbosity != None %}

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -21,8 +21,8 @@ controller_workflows:
 {% if node.summary_fields.unified_job_template is not defined %}
         unified_job_template: "ToDo: The node is pointing to a deleted Job Template"
 {% endif %}
-{% if node.summary_fields.unified_job_template is defined and
-      node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
+{% if     node.summary_fields.unified_job_template is defined
+      and node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
         unified_job_template: "{{ node.summary_fields.unified_job_template.name }}"
 {%   if node.verbosity != None %}
         verbosity: "{{ node.verbosity }}"
@@ -43,8 +43,8 @@ controller_workflows:
 {% endif %}
 {% if node.job_type %}
         job_type: "{{ node.job_type }}"
-{%   if node.summary_fields.unified_job_template is defined and
-        node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
+{%   if     node.summary_fields.unified_job_template is defined
+        and node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
         approval_node:
           description: "{{ node.summary_fields.unified_job_template.description }}"
           name: "{{ node.summary_fields.unified_job_template.name }}"

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -18,8 +18,9 @@ controller_workflows:
         inventory: "{{ node.summary_fields.inventory.name }}"
 {% endif %}
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
-{% if node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
-        unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template') }}"
+{% if node.summary_fields.unified_job_template is defined and
+      node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
+        unified_job_template: "{{ node.summary_fields.unified_job_template.name }}"
 {%   if node.verbosity != None %}
         verbosity: "{{ node.verbosity }}"
 {%   else %}
@@ -39,12 +40,13 @@ controller_workflows:
 {% endif %}
 {% if node.job_type %}
         job_type: "{{ node.job_type }}"
-{% if node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
+{%   if node.summary_fields.unified_job_template is defined and
+        node.summary_fields.unified_job_template.unified_job_type is match('approval') %}
         approval_node:
           description: "{{ node.summary_fields.unified_job_template.description }}"
           name: "{{ node.summary_fields.unified_job_template.name }}"
           timeout: {{ node.summary_fields.unified_job_template.timeout }}
-{% endif %}
+{%   endif %}
 {% endif %}
         organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
         all_parents_must_converge: "{{ node.all_parents_must_converge }}"

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -18,7 +18,10 @@ controller_workflows:
         inventory: "{{ node.summary_fields.inventory.name }}"
 {% endif %}
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
-{% if node.summary_fields.unified_job_template is defined and
+{% if node.summary_fields.unified_job_template is not defined %}
+        unified_job_template: "ToDo: The node is pointing to a deleted Job Template"
+{% endif %}
+{% if node.summary_fields.unified_job_template is defined 
       node.summary_fields.unified_job_template.unified_job_type is not match('approval') %}
         unified_job_template: "{{ node.summary_fields.unified_job_template.name }}"
 {%   if node.verbosity != None %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Resolves an issue where the Workflow Job Template exportation failed if there were a workflow node without a `unified_job_template` defined. This can happen when a Job Template is deleted from the Controller and a Workflow that was using that Job Template is not being updated accordingly.
## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!-- resolves #[number] -->
N/A
## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A