### PR TITLE
Avoid job_templates or workflow_job_templates export failure if all their extra_vars are commented

### DIFF
--- a/changelogs/fragments/filtree_commented_extra_vars_.yaml
+++ b/changelogs/fragments/filtree_commented_extra_vars_.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "filetree_create - Avoid job_templates and workflow_job_templates export failure if all their extra_vars are commented"

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -123,7 +123,7 @@ controller_templates:
 {% endif %}
 {% if template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars is defined
       or template_overrides_global.job_template.extra_vars is defined
-      or current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}
+      or current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | from_yaml | string is not match('None') %}
     extra_vars:
 {% set extra_vars_contents = template_overrides_resources.job_template[current_job_templates_asset_value.name].extra_vars
                              | default(template_overrides_global.job_template.extra_vars)

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -107,7 +107,7 @@ controller_workflows:
                          | default(current_workflow_job_templates_asset_value.webhook_service) }}"
 {% if template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars is defined
       or template_overrides_global.workflow_template.extra_vars is defined
-      or (current_workflow_job_templates_asset_value.extra_vars and current_workflow_job_templates_asset_value.extra_vars | length > 3) %}
+      or (current_workflow_job_templates_asset_value.extra_vars and current_workflow_job_templates_asset_value.extra_vars | from_yaml | string is not match('None')) %}
     extra_vars:
 {% set extra_vars_contents = template_overrides_resources.workflow_job_template[current_workflow_job_templates_asset_value.name].extra_vars
                              | default(template_overrides_global.workflow_job_template.extra_vars)


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Avoid job_templates or workflow_job_templates export failure if all their extra_vars are commented
Fix bug [#44 ]( https://github.com/redhat-cop/infra.controller_configuration/issues/44)

## How should this be tested?
- in AAP create a job template
- for that job template, create extra_vars and comment all of them
- run the filetree_create
-> the export will fail

apply the fix and re-run the export -> the export will succeed

## Is there a relevant Issue open for this?
[#44 ]( https://github.com/redhat-cop/infra.controller_configuration/issues/44)

## Other Relevant info, PRs, etc
N/A