### PR TITLE
Fix variable name for secure logging in workflows

### DIFF
--- a/changelogs/fragments/fix_typo_workflow_job_templates_secure_logging.yml
+++ b/changelogs/fragments/fix_typo_workflow_job_templates_secure_logging.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixes an typo in add_workflows_schema.yml task file. 
+...

--- a/roles/workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/workflow_job_templates/tasks/add_workflows_schema.yml
@@ -71,7 +71,7 @@
       loop_control:
         loop_var: __workflows_node_async_results_item
       vars:
-        cas_secure_logging: "{{ workflows_job_templates_secure_logging }}"
+        cas_secure_logging: "{{ workflow_job_templates_secure_logging }}"
         cas_async_delay: "{{ controller_configuration_workflow_async_delay }}"
         cas_async_retries: "{{ controller_configuration_workflow_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_node_async_results_item }}"
@@ -124,7 +124,7 @@
       loop_control:
         loop_var: __workflows_link_async_results_item
       vars:
-        cas_secure_logging: "{{ workflows_job_templates_secure_logging }}"
+        cas_secure_logging: "{{ workflow_job_templates_secure_logging }}"
         cas_async_delay: "{{ controller_configuration_workflow_async_delay }}"
         cas_async_retries: "{{ controller_configuration_workflow_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_link_async_results_item }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Typo in secure_logging of workflow templates. Silently failing without being able to see the error in pipeline since its no_log

## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
