### PR TITLE
Allow removing credentials from job templates if they are not set or set to empty when job_template_enforce_defaults is true

### DIFF
--- a/changelogs/fragments/job_templates_llow_empty_credentials.yml
+++ b/changelogs/fragments/job_templates_llow_empty_credentials.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "job_templates - if job templates enforce defaults is true, allow credentials to be removed from JT if not set or set to empty value"

--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -21,7 +21,7 @@
         project: "{{ __controller_template_item.project.name | default(__controller_template_item.project | default(omit, true)) }}"
         playbook: "{{ __controller_template_item.playbook | default(omit, true) }}"
         credentials: "{{ __controller_template_item.credentials | default(__controller_template_item.related.credentials | default([]) | map(attribute='name') | list)
-          | default(omit, true) }}"
+          | default(([] if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
         forks: "{{ __controller_template_item.forks | default(0, true) if __controller_template_item.forks is defined or controller_configuration_job_templates_enforce_defaults
           else omit }}"
         limit: "{{ __controller_template_item.limit | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
In AAP, if a job templates have credentials there is no way to remove it using configuration as code.
This PR makes it possible to do so if job_template_enforce_defaults is set to true, and if the user do not set the credential or set an empty credential in the JT yaml definition.

It is worth noting that this change might result unwanted behavior if configuration as code is not reflecting real world AAP configuration:
Example : 
if 
1. the JT already has a credential in AAP
2. the user declare the same JT (same name) in configuration as code without declaring his credential
3. job_template_enforce_defaults is set to true
4. the user apply the conf as code

then the credential will be removed from the JT.

## How should this be tested?

1. set JT enforce defaults to true
6. set a credential in the JT (via conf as code or via UI)
7. from the job template conf as code yaml, remove the credentials key or set to empty value
8. apply the conf as code
9. the JT credential is removed

## Is there a relevant Issue open for this?
N/A

## Other Relevant info, PRs, etc
N/A
