### PR TITLE
Remove the -devel sufix of the generated release

### DIFF
--- a/.github/workflows/release_auto.yml
+++ b/.github/workflows/release_auto.yml
@@ -135,9 +135,9 @@ jobs:
       - name: Install dependencies
         run: pip install --upgrade "ansible-core>=2.15,<2.19" antsibull-changelog
 
-      - name: Update galaxy.yml version for changelog
+      - name: Update galaxy.yml version for changelog (remove -devel)
         run: |
-          sed -i "s/^version:.*/version: ${{ needs.calculate_version.outputs.collection_version }}-devel/" galaxy.yml
+          sed -i "s/^version:.*/version: ${{ needs.calculate_version.outputs.collection_version }}/" galaxy.yml
 
       - name: Generate changelog
         run: antsibull-changelog release --verbose --version ${{ needs.calculate_version.outputs.collection_version }}
@@ -257,7 +257,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GH_WORKFLOW_KEY }}
-          file: "${{ env.COLLECTION_NAMESPACE }}-${{ env.COLLECTION_NAME }}-*.tar.gz"
+          file: "${{ env.COLLECTION_NAMESPACE }}-${{ env.COLLECTION_NAME }}*.tar.gz"
           file_glob: true
           tag: ${{ needs.calculate_version.outputs.collection_version }}
           overwrite: true


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Generates the correct version when a new release is generated.

Current behaviour:

<img width="804" height="599" alt="image" src="https://github.com/user-attachments/assets/48667bfb-8874-4c5d-b227-901efcb8fa52" />

## How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
A new release must be generated to test the fix
## Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!-- resolves #[number] -->
N/A
## Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A