### PR TITLE
Security audit: CodeQL checkout fix, pinned Actions, gitignore hygiene

### DIFF
--- a/.github/workflows/build-import.yml
+++ b/.github/workflows/build-import.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   build-import:
-    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@8d811a21e588dc6692299797e9a2bab1205365dc # main

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   changelog:
-    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@8d811a21e588dc6692299797e9a2bab1205365dc # main

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -32,5 +32,3 @@ jobs:
     uses: "./.github/workflows/ci_standalone_versioned.yml"
     with:
       awx_version: ${{ matrix.awx_version }}
-      gh_ref: ${{ github.event.pull_request.head.sha || github.sha }}
-...

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -1,22 +1,13 @@
 ---
 name: Test collection with AWX
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      awx_version:
+        description: The version of AWX to pull
+        required: true
+        type: string
 
-# on:
-#   workflow_call:
-#     inputs:
-#       awx_version:
-#         description: The version to pull of awx
-#         required: true
-#         type: string
-#       gh_ref:
-#         description: The ref in the repository to pull
-#         required: false
-#         default: devel
-#         type: string
 env:
   # Run docker-compose up in the background
   COMPOSE_UP_OPTS: -d
@@ -29,18 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.awx_version == 'devel' }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.gh_ref }}
+      # Implicit ref: same commit as the caller workflow (avoids untrusted PR checkout)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout AWX
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ansible/awx
           path: awx
           ref: ${{ inputs.awx_version }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 
@@ -97,4 +87,3 @@ jobs:
 
       - name: "Perform export model playbook tests"
         run: ansible-playbook tests/configure_controller_export_model.yml -e controller_hostname=localhost:8043 -v -e awx_version=${{ inputs.awx_version }}
-...

--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -20,4 +20,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'inactive'
           inactive-day: 7
-...

--- a/.github/workflows/issue-find-inactive.yml
+++ b/.github/workflows/issue-find-inactive.yml
@@ -21,4 +21,3 @@ jobs:
           inactive-day: 30
           issue-state: open
           exclude-labels: 'new,enhancement,backlog,help wanted,module-issue,blocked - upstream'
-...

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -22,4 +22,3 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             Hello @${{ github.event.issue.user.login }}. Please ensure that you have filled out the issue template as much as possible and have answered any further questions asked. If you have not done so in the next 7 days this issue will be automatically closed.'
-...

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -22,4 +22,3 @@ jobs:
           actions: 'remove-labels'
           issue-number: ${{ github.event.issue.number }}
           labels: 'inactive'
-...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,8 +15,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/release_auto.yml
+++ b/.github/workflows/release_auto.yml
@@ -25,7 +25,7 @@ jobs:
       change_level: ${{ steps.bump_level.outputs.level }}
       change_present: ${{ steps.bump_level.outputs.change_present }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -125,7 +125,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: "${{ secrets.GH_WORKFLOW_KEY }}"
@@ -135,7 +135,7 @@ jobs:
           BRANCH="release/${{ needs.calculate_version.outputs.collection_version }}"
           git checkout -B "${BRANCH}"
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 
@@ -183,7 +183,7 @@ jobs:
       contents: read
     environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release/${{ needs.calculate_version.outputs.collection_version }}
 
@@ -205,7 +205,7 @@ jobs:
       contents: read
     environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release/${{ needs.calculate_version.outputs.collection_version }}
 
@@ -251,7 +251,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release/${{ needs.calculate_version.outputs.collection_version }}
 
@@ -278,7 +278,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release/${{ needs.calculate_version.outputs.collection_version }}
 
@@ -296,7 +296,7 @@ jobs:
   deploy_ee:
     name: Build Execution Environment
     needs: merge_release
-    uses: redhat-cop/ansible_collections_tooling/.github/workflows/build_ee.yml@main
+    uses: redhat-cop/ansible_collections_tooling/.github/workflows/build_ee.yml@634342818b5d5fa2fa92b2c68c78a2bbe8aa4f10 # main
     with:
       quay_username: redhat_cop
     secrets:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   sanity:
-    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@8d811a21e588dc6692299797e9a2bab1205365dc # main

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.env
+*.pem
+*.key
 ansible_collections
 *.tar.gz
 *.pyc


### PR DESCRIPTION
## Summary

This PR applies security hardening from a DevSecOps audit of `infra.controller_configuration`.

### 1. Code scanning (CodeQL) — alert #31

- **Rule:** `actions/untrusted-checkout/medium` — checkout of untrusted code in a privileged context.
- **Location:** `.github/workflows/ci_standalone_versioned.yml` (checkout with `ref: ${{ inputs.gh_ref }}`).
- **Fix:** The reusable workflow now uses `on: workflow_call` only (correct for a called workflow). The collection repo is checked out **without** an explicit `ref`, so the implicit ref is the **same commit SHA as the caller workflow** (trusted context). The `gh_ref` input was removed from the caller matrix workflow.
- **Note:** The previous file mixed `on: push` with `inputs.*`, which is invalid for direct `push` runs; the callable workflow is only invoked from `ci_standalone.yml`.

### 2. `pull_request_target`

- **Finding:** No workflows use `pull_request_target`. No `environment: pr-approval` blocks were added (not applicable).

### 3. Dependabot

- **Finding:** `.github/dependabot.yml` already exists with `github-actions`, `pip`, and `pre-commit`. No change.

### 4. Additional hardening

- **Least privilege:** All workflows already had explicit `permissions:` at workflow or job level; no gaps found.
- **Pin Actions by SHA:** Replaced mutable `@v6` / `@main` references with full commit SHAs for:
  - `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
  - `actions/setup-python` → `a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6.2.0)
  - `ansible/ansible-content-actions` reusable workflows → `8d811a21e588dc6692299797e9a2bab1205365dc` (main at pin time)
  - `redhat-cop/ansible_collections_tooling` `build_ee.yml` → `634342818b5d5fa2fa92b2c68c78a2bbe8aa4f10` (main at pin time)
- **Secret hygiene:** `.gitignore` now includes `.env`, `*.pem`, and `*.key`.
- **YAML cleanup:** Removed stray `...` document-end lines from issue-helper workflows (cosmetic / avoids confusion).

### Post-merge

- Re-run CodeQL on `devel` after merge to confirm alert #31 closes.
- Periodically bump pinned SHAs (e.g. via Dependabot PRs) for `github-actions` ecosystem updates.


Made with [Cursor](https://cursor.com)