### PR TITLE
docs: update minimum ansible-core to 2.16 and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ collections:
 
 |                                      Collection Name                                                  |                      Purpose                      |
 |:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
-| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                   | Ansible Automation Platform configuration |
+| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                     | Ansible Automation Platform configuration         |
 | [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
 | [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                            | Execution Environment creation utilities          |
 | [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                             | Ansible Automation Platform Utilities             |

--- a/README.md
+++ b/README.md
@@ -38,19 +38,24 @@ collections:
 
 ## Links to Ansible Automation Platform Collections
 
-| Collection Name                                                                              | Purpose                                  |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| [awx.awx/Ansible.controller repo](https://github.com/ansible/awx/tree/devel/awx_collection)  | Automation controller modules            |
-| [Ansible Hub Configuration](https://github.com/ansible/automation_hub_collection)            | Automation hub configuration             |
+|                                      Collection Name                                |            Purpose            |
+|:-----------------------------------------------------------------------------------:|:-----------------------------:|
+| [ansible.platform repo](https://github.com/ansible/ansible.platform)                | gateway/platform modules      |
+| [ansible.hub repo](https://github.com/ansible-collections/ansible_hub)              | Automation hub modules        |
+| [ansible.controller repo](https://github.com/ansible/awx/tree/devel/awx_collection) | Automation controller modules |
+| [ansible.eda repo](https://github.com/ansible/event-driven-ansible)                 | Event Driven Ansible modules  |
 
 ## Links to other Validated Configuration Collections for Ansible Automation Platform
 
-| Collection Name                                                                           | Purpose                                  |
-| ----------------------------------------------------------------------------------------- | ---------------------------------------- |
-| [Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration)  | Automation controller configuration      |
-| [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                | Execution Environment creation utilities |
-| [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                 | Ansible Automation Platform Utilities    |
-| [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)    | Configuration Template for this suite    |
+|                                      Collection Name                                                  |                      Purpose                      |
+|:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
+| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                   | Ansible Automation Platform configuration |
+| [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
+| [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                            | Execution Environment creation utilities          |
+| [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                             | Ansible Automation Platform Utilities             |
+| [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)                | Configuration Template for this suite             |
+| [Ansible Validated Gitlab Workflows](https://gitlab.com/redhat-cop/infra/ansible_validated_workflows) | Gitlab CI/CD Workflows for ansible content        |
+| [Ansible Validated GitHub Workflows](https://github.com/redhat-cop/infra.ansible_validated_workflows) | GitHub CI/CD Workflows for ansible content        |
 
 ## Included content
 
@@ -253,3 +258,7 @@ Please read and familiarize yourself with this document.
 GNU General Public License v3.0 or later.
 
 See [LICENSE](https://github.com/redhat-cop/infra.controller_configuration/blob/devel/LICENSE) to see the full text.
+
+## Support
+
+This collection is [Ansible Validated Content](https://access.redhat.com/articles/3166901). It is reviewed and tested by Red Hat but is not supported under a Red Hat SLA. For reporting issues and requesting improvements, file an issue at the [Controller Configuration repository](https://github.com/redhat-cop/infra.controller_configuration/issues). Community help is also available on the [Ansible Forum](https://forum.ansible.com/tag/infra-config-as-code).

--- a/changelogs/fragments/certification-review-updates.yaml
+++ b/changelogs/fragments/certification-review-updates.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - README - Standardized collection links tables and added Support section for certification review.
+  - meta/runtime.yml - Updated minimum ansible-core version from 2.15 to 2.16.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 ...


### PR DESCRIPTION
## Summary
- Update `requires_ansible` in `meta/runtime.yml` from `>=2.15.0` to `>=2.16.0` per AAP 2.4 lifecycle end
- Standardize "Links to Ansible Automation Platform Collections" table with current repos (ansible.platform, ansible.hub, ansible.controller, ansible.eda)
- Standardize "Links to other Validated Configuration Collections" table with all sibling collections
- Add Support section clarifying this is Ansible Validated Content, directing users to GitHub issues and community forum

## Changes
- `meta/runtime.yml`: Bump minimum ansible-core version
- `README.md`: Updated both links tables, added Support section
- `changelogs/fragments/certification-review-updates.yaml`: Changelog fragment

## References
- [AAP ending support for ansible-core 2.15](https://forum.ansible.com/t/red-hat-ansible-automation-platform-is-ending-support-for-ansible-core-2-15-and-python-3-11/45574)

## Test plan
- [ ] Pre-commit checks pass
- [ ] Changelog fragment added in `changelogs/fragments/`
- [ ] `ansible-test sanity` passes against Core 2.16 + Python 3.12
- [ ] README renders correctly on GitHub


Made with [Cursor](https://cursor.com)