### PR TITLE
explicit type conversion for Ansible 2.20 compatibility

### DIFF
--- a/changelogs/fragments/explicit_type_conversion.yaml
+++ b/changelogs/fragments/explicit_type_conversion.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - filetree_create - changed ``user_roles.yaml`` and ``team_roles.yaml`` to have explicit type conversion for Ansible 2.20

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: team_roles | Get current Team Roles from the API
   ansible.builtin.set_fact:
-    team_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/' + team_id + '/roles/', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+    team_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/' + team_id | string + '/roles/', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
       return_all=true, max_objects=query_controller_api_max_objects) }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: user_roles | Get current Users from the API
   ansible.builtin.set_fact:
-    user_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/users/' + __user_id + '/roles/', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+    user_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/users/' + __user_id | string + '/roles/', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
       return_all=true, max_objects=query_controller_api_max_objects) }}"
   vars:
     __user_id: "{{ lookup(controller_api_plugin, 'users', query_params={'username': username}, expect_one=true, host=controller_hostname, oauth_token=controller_oauthtoken,


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Eliminates type conversion errors in user_roles and team_roles, similar to following:
Error while resolving value for 'user_roles_lookvar': Error rendering template: can only concatenate str (not \"_AnsibleTaggedInt\") to str"

## How should this be tested?
Run export.sh using Ansible 2.20 (discovered with 2.20.5)

## Is there a relevant Issue open for this?
No