### PR TITLE
update var to match what is used in template

### DIFF
--- a/changelogs/fragments/filetree-create-fix-var-in-hosts-tasks.yaml
+++ b/changelogs/fragments/filetree-create-fix-var-in-hosts-tasks.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - filetree_create - rename ``first_group`` to ``first_hosts`` in ``hosts.yml`` tasks to match the variable name in the template

--- a/roles/filetree_create/tasks/hosts.yml
+++ b/roles/filetree_create/tasks/hosts.yml
@@ -28,7 +28,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_hosts.j2') }}"
       vars:
-        first_group: "{{ not (__hosts_file.stat.exists | bool) }}"
+        first_hosts: "{{ not (__hosts_file.stat.exists | bool) }}"
 
     - name: hosts | Remove all the blank lines introduced by the last task
       ansible.builtin.lineinfile:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Renames `first_group` to `first_hosts` in `hosts.yml` tasks to match the variable name in the template

## How should this be tested?
Exports hosts as usual

## Is there a relevant Issue open for this?
N/A

## Other Relevant info, PRs, etc
N/A
